### PR TITLE
Lint and format docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
+# Editors
+**/*.idea/
+**/*.vscode/
+**/*~
+**/*.swp
 
-.env
+# Environment
+**/.env
 
-*.xml
+# Other
+**/*.xml
+**/errors.*
 
-.idea/
-
-.vscode/
-
-errors.*
+# Runtimes
+**/package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ include:
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
-advances.
+  advances.
 * Trolling, insulting/derogatory comments, and personal or political attacks.
 * Public or private harassment.
 * Publishing others' private information, such as a physical or electronic

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,39 +3,40 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+contributors and maintainers pledge to making participation in our project
+and our community a harassment-free experience for everyone, regardless of
+age, body size, disability, ethnicity, sex characteristics, gender identity
+and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
 ## Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Using welcoming and inclusive language.
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive criticism.
+* Focusing on what is best for the community.
+* Showing empathy towards other community members.
 
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+advances.
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+* Public or private harassment.
 * Publishing others' private information, such as a physical or electronic
- address, without explicit permission
+  address, without explicit permission.
 * Other conduct which could reasonably be considered inappropriate in a
- professional setting
+  professional setting.
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair corrective
+action in response to any instances of unacceptable behaviour.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
@@ -48,18 +49,19 @@ threatening, offensive, or harmful.
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of
 representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at cp (at) cpdev (dot) me. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances. The project
+team is obligated to maintain confidentiality with regard to the reporter of
+an incident. Further details of specific enforcement policies may be posted
+separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
@@ -67,10 +69,12 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor
+Covenant][homepage], version 1.4, available [here][document].
+
+For answers to common questions about this code of conduct, see the
+[FAQ][faq]
 
 [homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[document]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+[faq]: https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ advances.
 
 Project maintainers are responsible for clarifying the standards of
 acceptable behavior and are expected to take appropriate and fair corrective
-action in response to any instances of unacceptable behaviour.
+action in response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,30 @@
-# Reporting Issues
-Got a feature idea or a bug report for the pom bot? Head on over to our Issue Tracker and see if it's been reported. If it has, add some details about your experience with the issue, and if it hasn't, go ahead and open a new issue. The more information about your issue, the more we can work with, so don't be afraid to get detailed!
+# CONTRIBUTING
 
-If you're the kind of person who wants to tackle the issue, leave a comment and we'll help you out. We'd love to have you on board.
+## Reporting Issues
 
-# Pull Request Guidelines
-Please adhere to the following guidelines. We want to avoid duplicate issues, reports, features, etc.
+Got a feature idea or a bug report for the pom bot? Head on over to our Issue
+Tracker and see if it's been reported. If it has, add some details about your
+experience with the issue, and if it hasn't, go ahead and open a new issue.
+The more information about your issue, the more we can work with, so don't be
+afraid to get detailed!
 
-1. Search the Issue Tracker for any relevant threads to what you're looking to create a PR for.
-2. Keep it detailed. We want to know your vision, and the more you give us the better discussion we can have!
-3. Please make sure you have read the license agreement. 
-4. Make a new branch to fork your changes from
+If you're the kind of person who wants to tackle the issue, leave a comment
+and we'll help you out. We'd love to have you on board.
+
+## Pull Request Guidelines
+
+Please adhere to the following guidelines. We want to avoid duplicate issues,
+reports, features, etc.
+
+1. Search the Issue Tracker for any relevant threads to what you're looking
+   to create a PR for.
+2. Keep it detailed. We want to know your vision, and the more you give us
+   the better discussion we can have!
+3. Please make sure you have read the license agreement.
+4. Make a new branch on your own fork for the changes.
 5. Make sure to test your bot on a local/personal testing Discord server
-6. Make sure your branch is updated with the master branch before sending your pull request, in case other changes have been made
-7. Make sure that your new feature is properly tested, and that it can pass all tests before submitting the pull request.
-8. Send your pull request to the develop branch
+6. Make sure your branch is updated with the master branch before sending
+   your pull request, in case other changes have been made
+7. Make sure that your new feature is properly tested, and that it can pass
+   all tests before submitting the pull request.
+8. Send your pull request to the develop branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,6 @@ reports, features, etc.
    your pull request, in case other changes have been made
 7. Make sure that your new feature is properly tested, and that it can pass
    all tests before submitting the pull request.
-8. Send your pull request to the develop branch.
+8. Send your pull request to the master branch of [pom-bot][upstream].
+
+[upstream]: https://github.com/knights-of-academia/pom-bot

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 The default pom bot with simple features.
 
-This version is made in Python3 and requires the discord.py wrapper:
-`pip3 install discord.py` 
+## Installation
 
-And the dotenv package:
-`pip3 install python-dotenv`
+1. Python 3.5.3 or newer.
 
-In addition to this, it's made with a MongoDB database, which is set to be running on localhost port 27017, which is the default port.
+2. The Python dependencies (`pip install -r requirements.txt`).
+
+3. MongoDB running on the default port (27017/tcp).
 
 After this has been set up, it should be plug and play! Enjoy!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Update the text width to 78 characters from an unspecified width.
Fix markdown linting problems.
Change language where appropriate.

Specifically:

- Contributing.md
    - There is no "develop" branch to try to merge to
        - Should I update this file?
    - changed point 4. in the PR guidelines from fork a branch -> branch a fork
- License.md
    - Are you happy with GPL? Seems like MIT or Apache is a better fit.
- package-lock.json
    - Why is a Node runtime file in a Python repo?
    - Deleted.
- Markdown
    - Set hard textwrap on all markdown to 78 characters.
    - Fix linting errors on markdown.
- .gitignore
    - Organize files into groups.
    - Alphabetize the groups.
