### PR TITLE
Remove passwords and fix dm exception

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
 # .env
+
+# Bot secret Discord token.
 DISCORD_TOKEN=''
-POM_CHANNEL_ID=''
+
+# Name of a channel to restrict the bot's response without the leading "#".
+POM_CHANNEL_NAME=''
+
+# Database credentials and details.
+MYSQL_HOST = ''
+MYSQL_USER = ''
+MYSQL_DATABASE = ''
+MYSQL_PASSWORD = ''

--- a/setup_tables.sql
+++ b/setup_tables.sql
@@ -1,0 +1,22 @@
+CREATE DATABASE IF NOT EXISTS pom_bot;
+USE pom_bot;
+
+DROP TABLE IF EXISTS poms;
+CREATE TABLE poms (
+    id INT(11) NOT NULL AUTO_INCREMENT,
+    userID BIGINT(20),
+    descript VARCHAR(30),
+    time_set TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    current_session TINYINT(1),
+    PRIMARY KEY(id)
+);
+
+DROP TABLE IF EXISTS events;
+CREATE TABLE events (
+    id INT(11) NOT NULL AUTO_INCREMENT,
+    event_name VARCHAR(100) NOT NULL,
+    pom_goal INT(11),
+    start_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    end_date TIMESTAMP NOT NULL DEFAULT 0,
+    PRIMARY KEY(id)
+);


### PR DESCRIPTION
I wanted to get this change in quickly to remove the passwords from the repository.

Changing how the bot restricts itself might be a source of debate. I've changed it the name of the channel rather than its ID because the 18-digit numeric ID is impossible to know without running (and debugging) the bot for the first time.

I've added a SQL setup script as well so a single developer can start working on the bot without needing further input. I'm not entirely sure if the fields are exactly correct, but _it works on my machine_. The README.md file should be updated to remove references to "MongoDB" and add information about using this file to create a database for use with the bot. _Nota bene: This is an initial setup/development-use tool only!_ It will delete the database every time it's run.

There was a silent exception being raised when the bot would send direct messages because DMs don't have some required attribute. This is fixed here.