### PR TITLE
Update to readme to reflect license requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ The original version of the software used MongoDB, this fork makes use of MySQL 
 ## Installation
 
 1. Python 3.5.3 or newer.
+
 2. The Python dependencies (`pip install -r requirements.txt`).
+
 3. MongoDB running on the default port (27017/tcp).
 
 After this has been set up, it should be plug and play! Enjoy!

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@ The default pom bot with simple features, based on the work of @moesgaarda found
 
 ## Changes to original software
 The original version of the software used MongoDB, this fork makes use of MySQL instead.
+
+# Installation
+
+1. Python 3.5.3 or newer.
+2. The Python dependencies (`pip install -r requirements.txt`).
+3. MongoDB running on the default port (27017/tcp).
+
+After this has been set up, it should be plug and play! Enjoy!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The default pom bot with simple features, based on the work of @moesgaarda found
 ## Changes to original software
 The original version of the software used MongoDB, this fork makes use of MySQL instead.
 
-# Installation
+## Installation
 
 1. Python 3.5.3 or newer.
 2. The Python dependencies (`pip install -r requirements.txt`).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # Pom Bot
+The default pom bot with simple features, based on the work of @moesgaarda found here: https://github.com/Moesgaarda/python-pom-bot
 
-The default pom bot with simple features.
-
-## Installation
-
-1. Python 3.5.3 or newer.
-
-2. The Python dependencies (`pip install -r requirements.txt`).
-
-3. MongoDB running on the default port (27017/tcp).
-
-After this has been set up, it should be plug and play! Enjoy!
+## Changes to original software
+The original version of the software used MongoDB, this fork makes use of MySQL instead.


### PR DESCRIPTION
Since the license (GNU GPLv3) requires stating changes, this has been added to the readme, which was highly outdated.

A new issue should be created to re-create the setup steps for a MySQL database.