### PR TITLE
Make object-relational mapping from Storage object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Other
 **/*.xml
 **/errors.*
+!**/errors.py
 
 # Runtimes
 **/package-lock.json

--- a/pombot/cogs/admin_commands.py
+++ b/pombot/cogs/admin_commands.py
@@ -30,7 +30,7 @@ class AdminCommands(commands.Cog):
         await ctx.send(f"Total amount of poms: {num_poms}")
 
     @commands.command(name="start", aliases=["start_event", "event"], hidden=True)
-    # @commands.has_any_role("Guardian", "Helper")  # FIXME
+    @commands.has_any_role("Guardian", "Helper")
     async def do_start_event(self, ctx: Context, *args):
         """Allows guardians and helpers to start an event.
 
@@ -136,7 +136,7 @@ class AdminCommands(commands.Cog):
         )
 
     @commands.command(name="remove_event", aliases=["delete_event"], hidden=True)
-    # @commands.has_any_role("Guardian", "Helper")  # FIXME
+    @commands.has_any_role("Guardian", "Helper")
     async def do_remove_event(self, ctx: Context, *args):
         """Allows guardians and helpers to start an event.
 

--- a/pombot/cogs/admin_commands.py
+++ b/pombot/cogs/admin_commands.py
@@ -9,7 +9,7 @@ from discord.ext.commands.bot import Bot
 from pombot.config import Reactions, Secrets
 from pombot.lib.embeds import send_embed_message
 from pombot.state import State
-from pombot.storage import EventSql
+from pombot.storage import EventSql, Storage
 
 
 class AdminCommands(commands.Cog):
@@ -26,18 +26,9 @@ class AdminCommands(commands.Cog):
 
         This is an admin-only command.
         """
-        db = mysql.connector.connect(
-            host=Secrets.MYSQL_HOST,
-            user=Secrets.MYSQL_USER,
-            database=Secrets.MYSQL_DATABASE,
-            password=Secrets.MYSQL_PASSWORD,
-        )
-        cursor = db.cursor(buffered=True)
-        cursor.execute('SELECT * FROM poms;')
-        num_poms = cursor.rowcount
-        cursor.close()
-        db.close()
+        num_poms = Storage.get_num_poms_for_all_users()
 
+        # FIXME in MR: should this be an embed and/or DM?
         await ctx.send(f"Total amount of poms: {num_poms}")
 
     @commands.command(name="start", aliases=["start_event"], hidden=True)
@@ -72,6 +63,7 @@ class AdminCommands(commands.Cog):
                 ```
             """)
 
+        # FIXME: YOU ARE HERE
         try:
             (*event_name, event_goal, start_month, start_day, end_month,
              end_day) = args

--- a/pombot/cogs/admin_commands.py
+++ b/pombot/cogs/admin_commands.py
@@ -141,5 +141,5 @@ class AdminCommands(commands.Cog):
 
 
 def setup(bot: Bot):
-    """Required to load extention."""
+    """Required to load extension."""
     bot.add_cog(AdminCommands(bot))

--- a/pombot/cogs/admin_commands.py
+++ b/pombot/cogs/admin_commands.py
@@ -41,7 +41,7 @@ class AdminCommands(commands.Cog):
         await ctx.send(f"Total amount of poms: {num_poms}")
 
     @commands.command(name="start", aliases=["start_event"], hidden=True)
-    @commands.has_any_role("Guardian", "Helper")
+    # @commands.has_any_role("Guardian", "Helper")
     async def do_start_event(self, ctx: Context, *args):
         """Allows guardians and helpers to start an event.
 

--- a/pombot/cogs/event_listeners.py
+++ b/pombot/cogs/event_listeners.py
@@ -47,6 +47,9 @@ async def _send_to_errors_channel(ctx: Context, message: str):
         _log.info("ERRORS_CHANNEL_NAME not configured")
         return
 
+    if ctx.guild is None:
+        return
+
     for channel in ctx.guild.channels:
         if channel.name == Config.ERRORS_CHANNEL_NAME:
             await channel.send("```\n" + message + "```")
@@ -130,5 +133,5 @@ class EventListeners(Cog):
 
 
 def setup(bot: Bot):
-    """Required to load extention."""
+    """Required to load extension."""
     bot.add_cog(EventListeners(bot))

--- a/pombot/cogs/user_commands.py
+++ b/pombot/cogs/user_commands.py
@@ -42,6 +42,7 @@ class UserCommands(commands.Cog):
         If the first word in the description is a number (1-10), multiple
         poms will be added with the given description.
         """
+        #FIXME you are here
         pom_count = 1
         current_date = datetime.now()
 
@@ -147,9 +148,8 @@ class UserCommands(commands.Cog):
 
         session_poms = [pom for pom in poms if pom.is_current_session()]
 
-        session_poms_with_description = Counter(
-            des_pom.descript
-            for des_pom in [pom for pom in session_poms if pom.descript])
+        descriptions = [pom.descript for pom in session_poms if pom.descript]
+        session_poms_with_description = Counter(descriptions)
 
         num_session_poms_without_description = len(session_poms) - sum(
             n for n in session_poms_with_description.values())
@@ -198,30 +198,30 @@ class UserCommands(commands.Cog):
         ))
 
     @commands.command()
-    async def undo(self, ctx: Context, *, description: str = None):
+    async def undo(self, ctx: Context, *, count: str = None):
         """Undo/remove your latest poms.
 
         Optionally specify a number to undo that many poms.
         """
-        count = 1
+        _count = 1
 
-        if description:
-            first_word, *_ = description.split(" ", 1)
+        if count:
+            first_word, *_ = count.split(" ", 1)
 
             try:
-                count = int(first_word)
+                _count = int(first_word)
             except ValueError:
                 await ctx.message.add_reaction(Reactions.WARNING)
                 await ctx.send(f"Please specify a number of poms to undo.")
                 return
 
-            if count > Config.POM_TRACK_LIMIT:
+            if not 0 < _count <= Config.POM_TRACK_LIMIT:
                 await ctx.message.add_reaction(Reactions.WARNING)
-                await ctx.send("You can only undo up to "
+                await ctx.send("You can only undo between 1 and "
                                f"{Config.POM_TRACK_LIMIT} poms at once.")
                 return
 
-        Storage.delete_most_recent_user_poms(ctx.author, count)
+        Storage.delete_most_recent_user_poms(ctx.author, _count)
         await ctx.message.add_reaction(Reactions.UNDO)
 
     @commands.command()

--- a/pombot/cogs/user_commands.py
+++ b/pombot/cogs/user_commands.py
@@ -11,7 +11,7 @@ from discord.ext.commands.bot import Bot
 from pombot.config import Config, Reactions
 from pombot.lib.embeds import send_embed_message
 from pombot.state import State
-from pombot.storage import EventSql, PomSql, Storage, Pom
+from pombot.storage import Storage, Pom
 
 
 def _get_duration_message(poms: List[Pom]) -> str:

--- a/pombot/config.py
+++ b/pombot/config.py
@@ -57,6 +57,7 @@ class Debug:
 class Reactions:
     """Static reaction emojis."""
     ABACUS = "🧮"
+    CHECKMARK = "✅"
     ERROR = "🐛"
     FALLEN_LEAF = "🍂"
     LEAVES = "🍃"

--- a/pombot/config.py
+++ b/pombot/config.py
@@ -38,6 +38,8 @@ class Config:
     # MySQL
     POMS_TABLE = "poms"
     EVENTS_TABLE = "events"
+    USE_CONNECTION_POOL = True
+    CONNECTION_POOL_SIZE = 5
 
     # Restrictions
     POM_CHANNEL_NAMES = [

--- a/pombot/errors.py
+++ b/pombot/errors.py
@@ -1,0 +1,13 @@
+"""Collection of Pombot's errors."""
+
+
+class EventError(Exception):
+    "Base exception for event errors."
+
+
+class EventCreationError(EventError):
+    "Failed to create event."
+
+
+class TooManyEventsError(EventError):
+    "Too many ongoing events."

--- a/pombot/storage.py
+++ b/pombot/storage.py
@@ -146,6 +146,15 @@ class Storage:
         return [Pom(*row) for row in rows]
 
     @classmethod
+    def add_poms_to_user_session(cls, user: User, descript: str, count: int):
+        descript = descript or None
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        poms = [(user.id, descript, now, True) for _ in range(count)]
+
+        with mysql_database_cursor() as cursor:
+            cursor.executemany(PomSql.INSERT_QUERY, poms)
+
+    @classmethod
     def clear_user_session_poms(cls, user: User):
         with mysql_database_cursor() as cursor:
             cursor.execute(PomSql.UPDATE_REMOVE_ALL_POMS_FROM_SESSION, (user.id, ))

--- a/pombot/storage.py
+++ b/pombot/storage.py
@@ -63,7 +63,7 @@ class EventSql:
     """
 
 @contextmanager
-def mysql_database_cursor():
+def _mysql_database_cursor():
     db_config = {
         "host": Secrets.MYSQL_HOST,
         "user": Secrets.MYSQL_USER,
@@ -90,7 +90,7 @@ class Storage:
     def get_num_poms_for_all_users(cls) -> int:
         query = f"SELECT * FROM {Config.POMS_TABLE};"
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query)
             num_rows = cursor.rowcount
 
@@ -103,7 +103,7 @@ class Storage:
             WHERE userID=%s;
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query, (user.id, ))
             rows = cursor.fetchall()
 
@@ -125,7 +125,7 @@ class Storage:
         now = dt.now().strftime("%Y-%m-%d %H:%M:%S")
         poms = [(user.id, descript, now, True) for _ in range(count)]
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.executemany(query, poms)
 
     @classmethod
@@ -137,7 +137,7 @@ class Storage:
             AND current_session = 1;
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query, (user.id, ))
 
     @classmethod
@@ -147,7 +147,7 @@ class Storage:
             WHERE userID=%s;
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query, (user.id, ))
 
     @classmethod
@@ -159,7 +159,7 @@ class Storage:
             LIMIT %s;
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query, (user.id, count))
 
     @classmethod
@@ -172,7 +172,7 @@ class Storage:
 
         current_date = dt.now()
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query, (current_date, current_date))
             rows = cursor.fetchall()
 
@@ -186,7 +186,7 @@ class Storage:
             AND time_set <= %s;
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query, (start, end))
             rows = cursor.fetchall()
 
@@ -204,7 +204,7 @@ class Storage:
             VALUES (%s, %s, %s, %s);
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             try:
                 cursor.execute(query, (name, goal, start, end))
             except mysql.connector.DatabaseError as exc:
@@ -218,7 +218,7 @@ class Storage:
             ORDER BY start_date;
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query)
             rows = cursor.fetchall()
 
@@ -235,7 +235,7 @@ class Storage:
             AND %s > start_date;
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query, (start, end))
             rows = cursor.fetchall()
 
@@ -250,5 +250,5 @@ class Storage:
             LIMIT 1;
         """
 
-        with mysql_database_cursor() as cursor:
+        with _mysql_database_cursor() as cursor:
             cursor.execute(query, (name, ))

--- a/pombot/storage.py
+++ b/pombot/storage.py
@@ -148,6 +148,16 @@ def mysql_database_cursor():
 
 class Storage:
     @classmethod
+    def get_num_poms_for_all_users(cls) -> int:
+        query = f"SELECT * FROM {Config.POMS_TABLE};"
+
+        with mysql_database_cursor() as cursor:
+            cursor.execute(query)
+            num_rows = cursor.rowcount
+
+        return num_rows
+
+    @classmethod
     def get_all_poms_for_user(cls, user: User) -> List[Pom]:
         with mysql_database_cursor() as cursor:
             cursor.execute(PomSql.SELECT_ALL_POMS_BY_USERID, (user.id, ))

--- a/pombot/storage.py
+++ b/pombot/storage.py
@@ -218,7 +218,7 @@ class Storage:
                 raise pombot.errors.EventCreationError(exc.msg)
 
     @classmethod
-    def get_all_events(cls, name: str = None) -> List[Event]:
+    def get_all_events(cls) -> List[Event]:
         query = f"""
             SELECT * FROM {Config.EVENTS_TABLE}
             ORDER BY start_date;

--- a/pombot/storage.py
+++ b/pombot/storage.py
@@ -11,7 +11,7 @@ from pombot.config import Config, Secrets
 
 @dataclass
 class Pom:
-    """A pom, as described in order from the database."""
+    """A pom, as described, in order, from the database."""
     pom_id: int
     user_id: int
     descript: str
@@ -82,6 +82,16 @@ class PomSql:
         ORDER BY time_set DESC
         LIMIT %s;
     """
+
+
+@dataclass
+class Event:
+    """An event, as described, in order, from the database."""
+    event_id: int
+    event_name: str
+    pom_goal: int
+    start_date: datetime
+    end_date: datetime
 
 
 class EventSql:
@@ -168,3 +178,21 @@ class Storage:
     def delete_most_recent_user_poms(cls, user: User, count: int):
         with mysql_database_cursor() as cursor:
             cursor.execute(PomSql.DELETE_RECENT_POMS_FOR_USER, (user.id, count))
+
+    @classmethod
+    def get_ongoing_events(cls) -> List[Event]:
+        current_date = datetime.now()
+
+        with mysql_database_cursor() as cursor:
+            cursor.execute(EventSql.SELECT_EVENT, (current_date, current_date))
+            rows = cursor.fetchall()
+
+        return [Event(*row) for row in rows]
+
+    @classmethod
+    def get_num_poms_for_date_range(cls, start: datetime, end: datetime) -> int:
+        with mysql_database_cursor() as cursor:
+            cursor.execute(PomSql.EVENT_SELECT, (start, end))
+            rows = cursor.fetchall()
+
+        return len(rows)


### PR DESCRIPTION
This PR translates calling the database and handling cursors and connections manually into calling a single object, and that object handles the cursors and connections.

I've also added a few feature commands like the user command `!events` to show current events and the admin command `!remove_event` to delete an event by name.

In addition to:

## 2020-10-18

    - Start ORM
        - Added connection pooling for Storage object calls.
        - !poms done
            - Chage text in embed so style for "designated" and
            "undesignated" poms match.
            - Removed some redundant SQL queries.
            - !poms now sends the "no tracked poms" message as an embed DM.
        - !howmany done
        - !newleaf done
            - Removed first checking for session poms as the only difference
              was the reaction emote.
        - !reset done
        - !undo done

## 2020-10-22

    - ORM
        - Finished user and admin commands
            - Added `!event` alias to start_event because  I kept typing it...
        - Storage object tidy.
    - Fixed `!poms` repeating descriptions on different lines if a user
      enters them out of order.
    - Response from `!total` should either be an embed or DM (or both?)
    - In `!poms` no more than one event can be going at the same time.
        - I've made this an error instead of being ignored like it used to.
        - This can be fixed by altering the "events" table to have a
          "goal_reached" boolean field and iterating over the events.
    - Events can no longer overlap.
        - `!start_event` won't allow an admin to create an overlapping event.
        - If an overlapping event exists anyways, `!pom` errors (but still
          gives credit for the pom).
    - New `!events` user command.

Please squash these commits on merge.