### PR TITLE
Remove defaults from events timestamps

### DIFF
--- a/pombot/storage.py
+++ b/pombot/storage.py
@@ -84,8 +84,8 @@ class Storage:
                     id INT(11) NOT NULL AUTO_INCREMENT,
                     event_name VARCHAR(100) NOT NULL,
                     pom_goal INT(11),
-                    start_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    end_date TIMESTAMP NOT NULL DEFAULT 0,
+                    start_date TIMESTAMP NOT NULL,
+                    end_date TIMESTAMP NOT NULL,
                     PRIMARY KEY(id)
                 );
             """


### PR DESCRIPTION
Some versions of MySQL don't support the `DEFAULT 0` syntax. Because the bot should not be able to update this table without providing both  the `start_date` and `end_date` values, this PR removes MySQL's use of defaults for these fields.

![new_events_tables](https://user-images.githubusercontent.com/8121097/98439376-6a6e1480-20e9-11eb-92c9-e68ef4a4bebe.png)
