### PR TITLE
Fix heavy attack chance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 
 test:
 	@echo "Testing..."
-	@${PYTHON} -m pytest -q -x --ff tests
+	@${PYTHON} -m pytest -x --ff tests
 
 dev: lint test
 	@echo "Launching..."

--- a/pombot/cogs/pom_wars_commands.py
+++ b/pombot/cogs/pom_wars_commands.py
@@ -96,8 +96,7 @@ def _is_attack_successful(
     is_heavy_attack: bool,
     timestamp: datetime,
 ) -> bool:
-    @cache
-    def _get_normal_attack_success_chance(num_poms: int):
+    def _delayed_exponential_drop(num_poms: int):
         operand = lambda x: math.pow(math.e, ((-(x - 9)**2) / 2)) / (math.sqrt(2 * math.pi))
 
         probabilities = {
@@ -115,8 +114,12 @@ def _is_attack_successful(
         return function(num_poms)
 
     @cache
-    def _get_heavy_attack_success_chance(num_poms):
-        return 1 / num_poms  # FIXME
+    def _get_normal_attack_success_chance(num_poms: int):
+        return 1.0 * _delayed_exponential_drop(num_poms)
+
+    @cache
+    def _get_heavy_attack_success_chance(num_poms: int):
+        return 0.25 * _delayed_exponential_drop(num_poms)
 
     chance_func = (_get_heavy_attack_success_chance
                    if is_heavy_attack else _get_normal_attack_success_chance)

--- a/pombot/cogs/pom_wars_commands.py
+++ b/pombot/cogs/pom_wars_commands.py
@@ -11,7 +11,6 @@ from typing import List
 from discord.ext import commands
 from discord.ext.commands import Context
 from discord.ext.commands.bot import Bot
-from discord.role import Role
 from discord.user import User
 
 from pombot import errors

--- a/pombot/lib/event_handlers.py
+++ b/pombot/lib/event_handlers.py
@@ -42,9 +42,9 @@ async def on_raw_reaction_add_handler(bot: Bot, payload: RawReactionActionEvent)
             knight_role = None
             viking_role = None
             for role in guild.roles:
-                if role.name == Pomwars.KNIGHTS_ROLE_NAME:
+                if role.name == Pomwars.KNIGHT_ROLE:
                     knight_role = role
-                if role.name == Pomwars.VIKINGS_ROLE_NAME:
+                if role.name == Pomwars.VIKING_ROLE:
                     viking_role = role
 
             if knight_role is not None and viking_role is not None:

--- a/tests/test_pom_war_attack_success_rates.py
+++ b/tests/test_pom_war_attack_success_rates.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+from unittest.mock import MagicMock, Mock, patch
+
+from pombot.cogs.pom_wars_commands import _is_attack_successful
+
+# For vertical alignment.
+TRU = True
+FLS = False
+
+
+@patch("pombot.storage.Storage.get_actions")
+@patch("random.random")
+def test_normal_attack_success_rate(random_mock: Mock, get_actions_mock: Mock):
+    """Generically test _is_attack_successful when doing a normal attack."""
+    dice_rolls_and_expected_outcomes = {
+        1: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU)],
+        2: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU)],
+        3: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU)],
+        4: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU)],
+        5: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU)],
+        6: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, FLS)],
+        7: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, FLS)],
+        8: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, TRU, FLS, FLS)],
+        9: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+            (TRU, TRU, TRU, TRU, TRU, TRU, TRU, FLS, FLS, FLS)],
+        10: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+             (TRU, TRU, TRU, TRU, TRU, TRU, FLS, FLS, FLS, FLS)],
+        11: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+             (TRU, FLS, FLS, FLS, FLS, FLS, FLS, FLS, FLS, FLS)],
+        12: [(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+             (FLS, FLS, FLS, FLS, FLS, FLS, FLS, FLS, FLS, FLS)],
+    }
+    user = MagicMock()
+    is_heavy_attack = False
+    timestamp = datetime.now()
+    actions = []
+
+    for pom_number, settings in dice_rolls_and_expected_outcomes.items():
+        actions.append(pom_number)
+        get_actions_mock.return_value = actions
+        print(f"len(actions) = {len(actions)}")
+
+        for dice_roll, expected_outcome in zip(*settings):
+            random_mock.return_value = dice_roll
+            actual_outcome = _is_attack_successful(user, is_heavy_attack, timestamp)
+
+            assert expected_outcome == actual_outcome, \
+                f"pom_number: {pom_number}, dice_roll: {dice_roll}"
+
+
+@patch("pombot.storage.Storage.get_actions")
+@patch("random.random")
+def test_heavy_attack_success_rate(random_mock: Mock, get_actions_mock: Mock):
+    """Generically test _is_attack_successful when doing a heavy attack."""
+    dice_rolls_and_expected_outcomes = {
+        1: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        2: [(0.1, 0.2, 0.3, 0.4),  # FIXME: actual results TBD
+            (TRU, TRU, FLS, FLS)],
+        3: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        4: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        5: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        6: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        7: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        8: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        9: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        10: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        11: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+        12: [(0.1, 0.2, 0.3, 0.4),
+            (TRU, TRU, FLS, FLS)],
+    }
+    user = MagicMock()
+    is_heavy_attack = True
+    timestamp = datetime.now()
+    actions = []
+
+    for pom_number, settings in dice_rolls_and_expected_outcomes.items():
+        actions.append(pom_number)
+        get_actions_mock.return_value = actions
+        print(f"len(actions) = {len(actions)}")
+
+        for dice_roll, expected_outcome in zip(*settings):
+            random_mock.return_value = dice_roll
+            actual_outcome = _is_attack_successful(user, is_heavy_attack, timestamp)
+
+            assert expected_outcome == actual_outcome, \
+                f"pom_number: {pom_number}, dice_roll: {dice_roll}"

--- a/tests/test_pom_war_attack_success_rates.py
+++ b/tests/test_pom_war_attack_success_rates.py
@@ -61,30 +61,18 @@ def test_normal_attack_success_rate(random_mock: Mock, get_actions_mock: Mock):
 def test_heavy_attack_success_rate(random_mock: Mock, get_actions_mock: Mock):
     """Generically test _is_attack_successful when doing a heavy attack."""
     dice_rolls_and_expected_outcomes = {
-        1: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        2: [(0.1, 0.2, 0.3, 0.4),  # FIXME: actual results TBD
-            (TRU, TRU, FLS, FLS)],
-        3: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        4: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        5: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        6: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        7: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        8: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        9: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        10: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        11: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
-        12: [(0.1, 0.2, 0.3, 0.4),
-            (TRU, TRU, FLS, FLS)],
+        1: [(0.1, 0.2, 0.3), (TRU, TRU, FLS)],
+        2: [(0.1, 0.2, 0.3), (TRU, TRU, FLS)],
+        3: [(0.1, 0.2, 0.3), (TRU, TRU, FLS)],
+        4: [(0.1, 0.2, 0.3), (TRU, TRU, FLS)],
+        5: [(0.1, 0.2, 0.3), (TRU, TRU, FLS)],
+        6: [(0.1, 0.2, 0.3), (TRU, TRU, FLS)],
+        7: [(0.1, 0.2, 0.3), (TRU, TRU, FLS)],
+        8: [(0.1, 0.2, 0.3), (TRU, TRU, FLS)],
+        9: [(0.1, 0.2, 0.3), (TRU, FLS, FLS)],
+        10: [(0.1, 0.2, 0.3), (TRU, FLS, FLS)],
+        11: [(0.1, 0.2, 0.3), (FLS, FLS, FLS)],
+        12: [(0.1, 0.2, 0.3), (FLS, FLS, FLS)],
     }
     user = MagicMock()
     is_heavy_attack = True


### PR DESCRIPTION
Fixed the `!attack heavy` to use the same delayed exponential drop-off as normal attacks.

Still no levels or upgrade stuff yet.

I've added a couple tests to make life easier when refactoring that horrible `_is_attack_successful` function.