### PR TITLE
Defend command fixup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 
 test:
 	@echo "Testing..."
-	@${PYTHON} -m pytest -x --ff tests
+	@${PYTHON} -m pytest -q -x --ff --disable-pytest-warnings tests
 
 build: test lint
 

--- a/pombot/cogs/pom_wars_commands.py
+++ b/pombot/cogs/pom_wars_commands.py
@@ -285,7 +285,7 @@ def _get_defensive_multiplier(team: str, timestamp: datetime) -> float:
         team=team,
         was_successful=True,
         date_range=DateRange(
-            timestamp - timedelta(minutes=Pomwars.DEFNED_DURATION_MINUTES),
+            timestamp - timedelta(minutes=Pomwars.DEFEND_DURATION_MINUTES),
             timestamp,
         ),
     )

--- a/pombot/config.py
+++ b/pombot/config.py
@@ -114,7 +114,7 @@ class Pomwars:
     HEAVY_QUALIFIERS = ["heavy", "hard", "sharp", "strong"]
 
     DEFEND_LEVEL_MULTIPLIERS = {1: 0.05, 2: 0.08, 3: 0.07, 4: 0.08, 5: 0.09}
-    DEFNED_DURATION_MINUTES = 30
+    DEFEND_DURATION_MINUTES = 30
     MAXIMUM_TEAM_DEFENCE = 0.25
 
     class Emotes:

--- a/pombot/config.py
+++ b/pombot/config.py
@@ -113,7 +113,8 @@ class Pomwars:
     HEAVY_PITY_INCREMENT = 0.10
     HEAVY_QUALIFIERS = ["heavy", "hard", "sharp", "strong"]
 
-    DEFEND_LEVEL_MULTIPLIERS = {1: 0.02, 2: 0.03, 3: 0.04, 4: 0.05, 5: 0.07}
+    DEFEND_LEVEL_MULTIPLIERS = {1: 0.05, 2: 0.08, 3: 0.07, 4: 0.08, 5: 0.09}
+    DEFNED_DURATION_MINUTES = 30
     MAXIMUM_TEAM_DEFENCE = 0.25
 
     class Emotes:


### PR DESCRIPTION
This started out as a bugfix for the errors when `!defend` was supplied with long descriptions or if they contained apostrophes, but a bunch of really minor tickets were added to github a little while ago, so I've included a couple of them as well.

Resolves #64, #62, and the mentioned bugs.