### PR TITLE
Call mysql asynchronously

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,6 @@ MYSQL_HOST = ''
 MYSQL_USER = ''
 MYSQL_DATABASE = ''
 MYSQL_PASSWORD = ''
-MYSQL_CONNECTION_POOL_SIZE = 10
 
 # The name of the channel to which bot errors are sent (in addition to the
 # log). Specify only one channel.

--- a/pombot/cogs/admin_commands.py
+++ b/pombot/cogs/admin_commands.py
@@ -61,10 +61,10 @@ class AdminCommands(commands.Cog):
                 await ctx.author.send(_usage(header=exc))
                 return
 
-            poms = Storage.get_poms(date_range=date_range)
+            poms = await Storage.get_poms(date_range=date_range)
             msg = f"Total amount of poms in range {date_range}: {len(poms)}"
         else:
-            poms = Storage.get_poms()
+            poms = await Storage.get_poms()
             msg = f"Total amount of poms since ever: {len(poms)}"
 
         await ctx.send(msg)
@@ -130,15 +130,16 @@ class AdminCommands(commands.Cog):
             await ctx.author.send(_usage(header=exc))
             return
 
-        if overlapping := Storage.get_overlapping_events(date_range):
+        overlapping_events = await Storage.get_overlapping_events(date_range)
+        if overlapping_events:
             msg = "Found overlapping events: {}".format(", ".join(
-                event.event_name for event in overlapping))
+                event.event_name for event in overlapping_events))
             await ctx.message.add_reaction(Reactions.ROBOT)
             await ctx.author.send(_usage(msg))
             return
 
         try:
-            Storage.add_new_event(event_name, pom_goal, date_range)
+            await Storage.add_new_event(event_name, pom_goal, date_range)
         except pombot.errors.EventCreationError as exc:
             await ctx.message.add_reaction(Reactions.ROBOT)
             await ctx.author.send(_usage(f"Failed to create event: {exc}"))
@@ -160,13 +161,12 @@ class AdminCommands(commands.Cog):
         )
 
     @commands.command(name="remove_event", aliases=["delete_event"], hidden=True)
-    @commands.has_any_role("Guardian", "Helper")
+    @commands.has_any_role("Guardian")
     async def do_remove_event(self, ctx: Context, *args):
-        """Allows guardians and helpers to start an event.
+        """Allows guardians to remove an existing event.
 
         This is an admin-only command.
         """
-
         if not args:
             cmd = ctx.prefix + ctx.invoked_with
 
@@ -180,7 +180,7 @@ class AdminCommands(commands.Cog):
             return
 
         name = " ".join(args).strip()
-        Storage.delete_event(name)
+        await Storage.delete_event(name)
         await ctx.message.add_reaction(Reactions.CHECKMARK)
 
     @commands.command(hidden=True)

--- a/pombot/cogs/event_listeners.py
+++ b/pombot/cogs/event_listeners.py
@@ -55,7 +55,7 @@ class EventListeners(Cog):
             for line in debug_enabled_message.split("\n"):
                 _log.info(line)
 
-        Storage.create_tables_if_not_exists()
+        await Storage.create_tables_if_not_exists()
 
         if Debug.DROP_TABLES_ON_RESTART:
             if not __debug__:
@@ -66,7 +66,7 @@ class EventListeners(Cog):
                 await self.bot.close()
                 raise RuntimeError(msg)
 
-            Storage.delete_all_rows_from_all_tables()
+            await Storage.delete_all_rows_from_all_tables()
 
         _log.info("READY ON DISCORD AS: %s", self.bot.user)
 

--- a/pombot/cogs/event_listeners.py
+++ b/pombot/cogs/event_listeners.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import random
 import textwrap
@@ -6,6 +7,7 @@ from typing import Any
 from discord.ext.commands import Bot, Cog, Context, errors
 
 from pombot.config import Config, Debug, Reactions, Secrets
+from pombot.state import State
 from pombot.storage import Storage
 
 _log = logging.getLogger(__name__)
@@ -36,9 +38,10 @@ class EventListeners(Cog):
     async def on_ready(self):
         """Startup procedure after bot has logged into Discord."""
         _log.info("MYSQL_DATABASE: %s", Secrets.MYSQL_DATABASE)
-
+        State.event_loop = asyncio.get_event_loop()
         active_channels = ", ".join(f"#{channel}"
                                     for channel in Config.POM_CHANNEL_NAMES)
+
         _log.info("POM_CHANNEL_NAMES: %s", active_channels or "ALL CHANNELS")
 
         debug_options_enabled = ", ".join([k for k, v in vars(Debug).items() if v is True])

--- a/pombot/cogs/user_commands.py
+++ b/pombot/cogs/user_commands.py
@@ -77,14 +77,14 @@ class UserCommands(commands.Cog):
             await ctx.send("Multi-line pom descriptions are disabled.")
             return
 
-        Storage.add_poms_to_user_session(ctx.author, description, count)
+        await Storage.add_poms_to_user_session(ctx.author, description, count)
         await ctx.message.add_reaction(Reactions.TOMATO)
 
         if State.goal_reached:
             return
 
         try:
-            ongoing_event, *other_ongoing_events = Storage.get_ongoing_events()
+            ongoing_event, *other_ongoing_events = await Storage.get_ongoing_events()
         except ValueError:
             # No ongoing events.
             return
@@ -93,7 +93,7 @@ class UserCommands(commands.Cog):
             msg = "Only one ongoing event supported."
             raise pombot.errors.TooManyEventsError(msg)
 
-        current_poms_for_event = Storage.get_poms(date_range=DateRange(
+        current_poms_for_event = await Storage.get_poms(date_range=DateRange(
             ongoing_event.start_date, ongoing_event.end_date))
 
         if len(current_poms_for_event) >= ongoing_event.pom_goal:
@@ -113,7 +113,7 @@ class UserCommands(commands.Cog):
 
         See details for your tracked poms and the current session.
         """
-        poms = Storage.get_poms(user=ctx.author)
+        poms = await Storage.get_poms(user=ctx.author)
         title = f"Pom statistics for {ctx.author.display_name}"
 
         if not poms:
@@ -161,7 +161,7 @@ class UserCommands(commands.Cog):
             await ctx.send("You must specify a description to search for.")
             return
 
-        poms = Storage.get_poms(user=ctx.author)
+        poms = await Storage.get_poms(user=ctx.author)
         matching_poms = [pom for pom in poms if pom.descript == description]
 
         if not matching_poms:
@@ -200,7 +200,7 @@ class UserCommands(commands.Cog):
                                f"{Config.POM_TRACK_LIMIT} poms at once.")
                 return
 
-        Storage.delete_most_recent_user_poms(ctx.author, _count)
+        await Storage.delete_most_recent_user_poms(ctx.author, _count)
         await ctx.message.add_reaction(Reactions.UNDO)
 
     @commands.command()
@@ -210,7 +210,7 @@ class UserCommands(commands.Cog):
         Hide the details of your previously tracked poms and start a new
         session.
         """
-        Storage.clear_user_session_poms(ctx.author)
+        await Storage.clear_user_session_poms(ctx.author)
 
         await ctx.send("A new session will be started when you track your "
                        f"next pom, <@!{ctx.author.id}>")
@@ -219,7 +219,7 @@ class UserCommands(commands.Cog):
     @commands.command(hidden=True)
     async def reset(self, ctx: Context):
         """Permanently deletes all of your poms. This cannot be undone."""
-        Storage.delete_all_user_poms(ctx.author)
+        await Storage.delete_all_user_poms(ctx.author)
         await ctx.message.add_reaction(Reactions.WASTEBASKET)
 
     @commands.command()
@@ -228,7 +228,7 @@ class UserCommands(commands.Cog):
         reported_events = []
 
         try:
-            ongoing_event, *_ = Storage.get_ongoing_events()
+            ongoing_event, *_ = await Storage.get_ongoing_events()
         except ValueError:
             pass
         else:
@@ -246,9 +246,11 @@ class UserCommands(commands.Cog):
 
             reported_events.append(ongoing_event)
 
+        all_events = await Storage.get_all_events()
+
         try:
             upcoming_event, *_ = [
-                event for event in Storage.get_all_events()
+                event for event in all_events
                 if event.start_date > datetime.now()
             ]
         except ValueError:

--- a/pombot/config.py
+++ b/pombot/config.py
@@ -51,8 +51,6 @@ class Config:
     EVENTS_TABLE = "events"
     USERS_TABLE = "users"
     ACTIONS_TABLE = "actions"
-    MYSQL_CONNECTION_POOL_SIZE = _positive_int(
-        os.getenv("MYSQL_CONNECTION_POOL_SIZE"))
 
     # Restrictions
     POM_CHANNEL_NAMES = [

--- a/pombot/errors.py
+++ b/pombot/errors.py
@@ -3,6 +3,9 @@
 
 class EventError(Exception):
     "Base exception for event errors."
+    def __init__(self, msg = None):
+        super().__init__(msg or self.__class__.__doc__)
+        self.msg = msg
 
 
 class EventCreationError(EventError):

--- a/pombot/lib/team.py
+++ b/pombot/lib/team.py
@@ -22,24 +22,27 @@ class Team(str, Enum):
         return icons[self]
 
     @property
-    def damage(self) -> int:
+    async def damage(self) -> int:
         """The team's total damage."""
-        return int(Storage.sum_team_damage(self.value) / 100.0)
+        return int(await Storage.sum_team_damage(self.value) / 100.0)
 
     @property
-    def favorite_action(self) -> ActionType:
+    async def favorite_action(self) -> ActionType:
         """The team's most-used action."""
-        count_actions = lambda type_: Storage.count_rows_in_table(
-            Config.ACTIONS_TABLE, action_type=type_, team=self.value)
+        async def _count_actions(typ: ActionType):
+            await Storage.count_rows_in_table(Config.ACTIONS_TABLE,
+                action_type=typ,
+                team=self.value,
+            )
 
-        return max({typ: count_actions(typ) for typ in ActionType})
+        return max({typ: await _count_actions(typ) for typ in ActionType})
 
     @property
-    def attack_count(self) -> int:
+    async def attack_count(self) -> int:
         """The team's total number of actions."""
-        return Storage.count_rows_in_table(Config.ACTIONS_TABLE, team=self.value)
+        return await Storage.count_rows_in_table(Config.ACTIONS_TABLE, team=self.value)
 
     @property
-    def population(self) -> int:
+    async def population(self) -> int:
         """The team's population."""
-        return Storage.count_rows_in_table(Config.USERS_TABLE, team=self.value)
+        return await Storage.count_rows_in_table(Config.USERS_TABLE, team=self.value)

--- a/pombot/scoreboard.py
+++ b/pombot/scoreboard.py
@@ -50,7 +50,7 @@ class Scoreboard:
             }
         }
 
-        if stats[knights] != stats[vikings]:
+        if stats[knights]["damage"] != stats[vikings]["damage"]:
             winner = knights if stats[vikings]["damage"] < stats[knights]["damage"] else vikings
 
         for channel in self.scoreboard_channels:

--- a/pombot/scoreboard.py
+++ b/pombot/scoreboard.py
@@ -37,16 +37,16 @@ class Scoreboard:
 
         stats = {
             knights: {
-                "damage":      knights.damage,
-                "fav_attack":  knights.favorite_action,
-                "population":  knights.population,
-                "num_attacks": knights.attack_count,
+                "damage":      await knights.damage,
+                "fav_attack":  await knights.favorite_action,
+                "population":  await knights.population,
+                "num_attacks": await knights.attack_count,
             },
             vikings: {
-                "damage":      vikings.damage,
-                "fav_attack":  vikings.favorite_action,
-                "population":  vikings.population,
-                "num_attacks": vikings.attack_count,
+                "damage":      await vikings.damage,
+                "fav_attack":  await vikings.favorite_action,
+                "population":  await vikings.population,
+                "num_attacks": await vikings.attack_count,
             }
         }
 

--- a/pombot/state.py
+++ b/pombot/state.py
@@ -1,10 +1,15 @@
-from pombot.scoreboard import Scoreboard
+from asyncio import ProactorEventLoop
 
 
 class State:
     """In-memory bot state."""
-    # Scoreboard
-    scoreboard: Scoreboard = None
+    # Discord creates an event loop for us. Instead of creating a new one, we
+    # can hook into the existing event loop to call our storage later.
+    event_loop: ProactorEventLoop = None
+
+    # pombot.scoreboard.Scoreboard object to preserve and dynamically update
+    # scoreboard channels in Pomwar events.
+    scoreboard = None
 
     # Tech debt: this should be in the database.
-    goal_reached = False
+    goal_reached: bool = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+aiomysql==0.0.21
 discord.py>=1.4.1
-mysql-connector-python>=8.0.20
 pylint==2.6.0
 pytest==6.1.2
 python-dotenv>=0.10.5


### PR DESCRIPTION
This is a draft to allow for some testing time.

I've removed the connection pooling because it works slightly differently than in `mysql-connector` and this was painful to get running in the first place. The original "bot stops working sometimes" bug from the times of lore was due to connections not being closed and was solved by using a Storage object and context managers; connection pooling was a nice bonus to alert us to when we were leaving zombie connections. I've left it out of this one for convenience. In order to test if this is a problem, we'll need to pom at least 65,533 times within 2 minutes.

I don't think this is possible because, while using `async` speeds it up a bunch, it doesn't speed it up as much as I had hoped. Instead of seeing 30 to 40-second delays after spamming 20 poms, i'm seeing 4 to 8 second delays (and then discord puts me in timeout).

There are probably more changes here that need talking about as well, but I've forgotten them. Expect me to comment below.