### PR TITLE
Remove Windows-only import

### DIFF
--- a/pombot/state.py
+++ b/pombot/state.py
@@ -1,11 +1,8 @@
-from asyncio import ProactorEventLoop
-
-
 class State:
     """In-memory bot state."""
     # Discord creates an event loop for us. Instead of creating a new one, we
     # can hook into the existing event loop to call our storage later.
-    event_loop: ProactorEventLoop = None
+    event_loop = None
 
     # Scoreboard object to preserve and dynamically update scoreboard channels
     # during Pomwar events.


### PR DESCRIPTION
I had used a type annotation of an object that I didn't realize was Windows-only and therefore raised an import error on the production host. Nothing was broken because this was only used to annotate an object initialized to `None`.

This is a cherry-pick of the fix from another branch.