### PR TITLE
PPB-50 remove nested usage

### DIFF
--- a/pombot/commands/create_event.py
+++ b/pombot/commands/create_event.py
@@ -7,7 +7,6 @@ import pombot
 from pombot.config import Reactions
 from pombot.lib.messages import send_embed_message
 from pombot.lib.storage import Storage
-from pombot.lib.tiny_tools import get_default_usage_header
 from pombot.lib.types import DateRange
 from pombot.state import State
 
@@ -15,38 +14,27 @@ from pombot.state import State
 async def do_create_event(ctx: Context, *args):
     """Create a new event.
 
-    This is an admin-only command.
+    Usage: !create_event <name> <goal> <start_month> <start_day> <end_month <end_day>
+
+    Where:\r
+        <name>         Name for this event.\r
+        <goal>         Number of poms to reach in this event.\r
+        <start_month>  Event starting month.\r
+        <start_day>    Event starting day.\r
+        <end_month>    Event ending month.\r
+        <end_day>      Event ending day.
+
+    Example:\r
+        !create_event The Best Event 100 June 10 July 4
+
+    At present, events must not overlap; only one concurrent event
+    can be ongoing at a time.
     """
-    def _usage(header: str = None):
-        cmd = ctx.prefix + ctx.invoked_with
-        header = header or get_default_usage_header(cmd, args)
-
-        return textwrap.dedent(f"""\
-            {header}
-            ```text
-            Usage: {cmd} <name> <goal> <start_month> <start_day> <end_month <end_day>
-
-            Where:
-                <name>         Name for this event.
-                <goal>         Number of poms to reach in this event.
-                <start_month>  Event starting month.
-                <start_day>    Event starting day.
-                <end_month>    Event ending month.
-                <end_day>      Event ending day.
-
-            Example:
-                {cmd} The Best Event 100 June 10 July 4
-
-            At present, events must not overlap; only one concurrent event
-            can be ongoing at a time.
-            ```
-        """)
-
     try:
         *name, pom_goal, start_month, start_day, end_month, end_day = args
     except ValueError:
+        await ctx.reply("Your args are out of order or something.")
         await ctx.message.add_reaction(Reactions.ROBOT)
-        await ctx.author.send(_usage())
         return
 
     event_name = " ".join(name)
@@ -57,38 +45,37 @@ async def do_create_event(ctx: Context, *args):
         if pom_goal <= 0:
             raise ValueError("Goal must be a positive number.")
     except ValueError as exc:
+        await ctx.reply(f"Invalid goal: `{pom_goal}`, {exc}")
         await ctx.message.add_reaction(Reactions.ROBOT)
-        await ctx.author.send(_usage(f"Invalid goal: `{pom_goal}`, {exc}"))
         return
 
     try:
         date_range = DateRange(start_month, start_day, end_month, end_day)
     except ValueError as exc:
+        await ctx.reply(exc)
         await ctx.message.add_reaction(Reactions.ROBOT)
-        await ctx.author.send(_usage(header=exc))
         return
 
     overlapping_events = await Storage.get_overlapping_events(date_range)
 
     if overlapping_events:
-        msg = "Found overlapping events: {}".format(", ".join(
-            event.event_name for event in overlapping_events))
+        await ctx.reply("Found overlapping events: {}".format(", ".join(
+            event.event_name for event in overlapping_events)))
         await ctx.message.add_reaction(Reactions.ROBOT)
-        await ctx.author.send(_usage(msg))
         return
 
     try:
         await Storage.add_new_event(event_name, pom_goal, date_range)
     except pombot.lib.errors.EventCreationError as exc:
+        await ctx.reply(f"Failed to create event: {exc}")
         await ctx.message.add_reaction(Reactions.ROBOT)
-        await ctx.author.send(_usage(f"Failed to create event: {exc}"))
         return
 
     State.goal_reached = False
     fmt = lambda dt: datetime.strftime(dt, "%B %d, %Y")
 
     await send_embed_message(
-        ctx,
+        None,
         title="New Event!",
         description=textwrap.dedent(f"""\
             Event name: **{event_name}**
@@ -97,4 +84,5 @@ async def do_create_event(ctx: Context, *args):
             Starts: *{fmt(date_range.start_date)}*
             Ends:   *{fmt(date_range.end_date)}*
         """),
+        _func=ctx.reply,
     )

--- a/pombot/commands/create_event.py
+++ b/pombot/commands/create_event.py
@@ -59,9 +59,7 @@ async def do_create_event(ctx: Context, *args):
         await ctx.message.add_reaction(Reactions.ROBOT)
         return
 
-    overlapping_events = await Storage.get_overlapping_events(date_range)
-
-    if overlapping_events:
+    if overlapping_events := await Storage.get_overlapping_events(date_range):
         await ctx.reply("Found overlapping events: {}".format(", ".join(
             event.event_name for event in overlapping_events)))
         await ctx.message.add_reaction(Reactions.ROBOT)

--- a/pombot/commands/create_event.py
+++ b/pombot/commands/create_event.py
@@ -14,7 +14,7 @@ from pombot.state import State
 async def do_create_event(ctx: Context, *args):
     """Create a new event.
 
-    Usage: !create_event <name> <goal> <start_month> <start_day> <end_month <end_day>
+    Usage: !create_event <name> <goal> <start_month> <start_day> <end_month> <end_day>
 
     Where:\r
         <name>         Name for this event.\r

--- a/pombot/commands/create_event.py
+++ b/pombot/commands/create_event.py
@@ -37,7 +37,10 @@ async def do_create_event(ctx: Context, *args):
         await ctx.message.add_reaction(Reactions.ROBOT)
         return
 
-    event_name = " ".join(name)
+    if not (event_name := " ".join(name)):  # pylint: disable=superfluous-parens
+        await ctx.reply("Please specify an event name.")
+        await ctx.message.add_reaction(Reactions.ROBOT)
+        return
 
     try:
         pom_goal = int(pom_goal)

--- a/pombot/commands/pom_wars/actions.py
+++ b/pombot/commands/pom_wars/actions.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import discord.errors
 from discord.ext.commands import Context
 
-from pombot.config import Debug, Pomwars, Reactions
+from pombot.config import Debug, IconUrls, Pomwars, Reactions
 from pombot.lib.messages import send_embed_message
 from pombot.lib.storage import Storage
 from pombot.lib.types import DateRange
@@ -70,7 +70,7 @@ async def do_actions(ctx: Context, *args):
             ctx,
             title=f"Actions for {date_range}",
             description=description,
-            icon_url=Pomwars.IconUrls.SWORD,
+            thumbnail=IconUrls.ATTACK,
             colour=Pomwars.ACTION_COLOUR,
             private_message=not Debug.POMS_COMMAND_IS_PUBLIC,
         )

--- a/pombot/commands/total.py
+++ b/pombot/commands/total.py
@@ -1,51 +1,33 @@
-import textwrap
-
 from discord.ext.commands import Context
 
 from pombot.config import Reactions
 from pombot.lib.storage import Storage
-from pombot.lib.tiny_tools import get_default_usage_header
 from pombot.lib.types import DateRange
 
 
 async def do_total(ctx: Context, *args):
     """Count the total poms for all users.
 
-    Optionally accepts a range of dates. If no range of dates is given, all
-    poms are tallied.
+    Usage: !total [<start_month> <start_day> <end_month <end_day>]
 
-    This is an admin-only command.
+    Where:\r
+        <start_month>  From this month...\r
+        <start_day>    ...And this day,\r
+        <end_month>    To this month...\r
+        <end_day>      ...And this day.
+
+    Example:\r
+        !total \r
+        !total january 1 january 31
+
+    The range of dates is optional. When omitted, all poms are counted.
     """
-    def _usage(header: str = None):
-        cmd = ctx.prefix + ctx.invoked_with
-        header = header or get_default_usage_header(cmd, args)
-
-        return textwrap.dedent(f"""\
-            {header}
-            ```text
-            Usage: {cmd} [<start_month> <start_day> <end_month <end_day>]
-
-            Where:
-                <start_month>  From this month...
-                <start_day>    ...And this day,
-                <end_month>    To this month...
-                <end_day>      ...And this day.
-
-            Example:
-                {cmd}
-
-                {cmd} january 1 january 31
-
-                If no range of dates is given, all poms are tallied.
-            ```
-        """)
-
     if args:
         try:
             date_range = DateRange(*args[-4:])
         except ValueError as exc:
+            await ctx.reply(exc)
             await ctx.message.add_reaction(Reactions.ROBOT)
-            await ctx.author.send(_usage(header=exc))
             return
 
         poms = await Storage.get_poms(date_range=date_range)
@@ -54,4 +36,4 @@ async def do_total(ctx: Context, *args):
         poms = await Storage.get_poms()
         msg = f"Total amount of poms since ever: {len(poms)}"
 
-    await ctx.send(msg)
+    await ctx.reply(msg)

--- a/pombot/lib/pom_wars/team.py
+++ b/pombot/lib/pom_wars/team.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 from discord.user import User
 
-from pombot.config import Pomwars, Config
+from pombot.config import Config, IconUrls, Pomwars
 from pombot.lib.pom_wars import errors as war_crimes
 from pombot.lib.storage import Storage
 from pombot.lib.types import ActionType
@@ -31,8 +31,8 @@ class Team(str, Enum):
     def get_icon(self):
         """Return the team's configured IconUrl."""
         icons = {
-            self.KNIGHTS: Pomwars.IconUrls.KNIGHT,
-            self.VIKINGS: Pomwars.IconUrls.VIKING,
+            self.KNIGHTS: IconUrls.VIKING,
+            self.VIKINGS: IconUrls.VIKING,
         }
 
         return icons[self]

--- a/pombot/lib/pom_wars/team.py
+++ b/pombot/lib/pom_wars/team.py
@@ -31,7 +31,7 @@ class Team(str, Enum):
     def get_icon(self):
         """Return the team's configured IconUrl."""
         icons = {
-            self.KNIGHTS: IconUrls.VIKING,
+            self.KNIGHTS: IconUrls.KNIGHT,
             self.VIKINGS: IconUrls.VIKING,
         }
 

--- a/pombot/lib/tiny_tools.py
+++ b/pombot/lib/tiny_tools.py
@@ -99,8 +99,13 @@ def normalize_newlines(text: str) -> str:
     ...     This line will be another paragraph in the message.
     ... ")
     >>> message_to_send = normalize_newlines(text_in_file)
+
+    As an attempt to give developers a means of forcing single-spaced lines,
+    any carriage return ("\r") will be replaced with newlines after the
+    initial normalization.
     """
-    return re.sub(r"(?<!\n)\n(?!\n)|\n{3,}", " ", text).strip()
+    normalized = re.sub(r"(?<!\n)\n(?!\n)|\n{3,}", " ", text).strip()
+    return normalized.replace("\r", "\n")
 
 
 def normalize_and_dedent(text: str) -> str:
@@ -137,23 +142,6 @@ def explode_after_char(word: str, char: str) -> List[str]:
     """
     pos = word[:-1].index(char)
     return [word[0:pos+2+i] for i in range(len(word) - (pos+1))]
-
-def get_default_usage_header(cmd: str, *args: tuple) -> str:
-    """Get a default header for use with the various nested _usage()
-    functions.
-
-    This function is entirely tech debt and should be removed once all
-    _usage() methods are deleted or moved.
-
-    @param cmd The prefix + invoked_with command.
-    @param args The args passed to the original function.
-    @return User-facing string indicating the command was invoked
-            incorrectly.
-    """
-    return normalize_and_dedent(f"""\
-        Your command `{cmd + ' ' + ' '.join(args)}` does not meet the usage
-        requirements.
-    """)
 
 
 class PolyStr(str):


### PR DESCRIPTION
Resolves PPB-50 by removing the nested `_usage` function definitions and call sites. The text has been moved into the standard `!help` information for the affected commands (`total` and `create_event`).

As a result of needing to single-space some help text, a workaround has been added to `normalize_newlines` and `normalize_and_dedent` which replaces carriage returns with newlines. This will be less useful in `message.txt` files than in source code because in a text file, git will replace all `\r\n`'s with `\n`'s, but in code we can specify the exact bytes we expect in a string.

This is not a problem now (tested by running `!attack` a few times and seeing the output is shaped correctly), but could present a novel issue when a writer expects to single-space lines (if ever).

Also, some bugs I noticed in testing were fixed.