### PR TITLE
PPB-54 bugfix embed too long with many poms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ lint:
 		bot.py \
 		pombot/*.py \
 		pombot/**/*.py \
-		tests/*.py
+		tests/*.py \
+		tests/**/*.py
 
 test:
 	@echo "Testing..."

--- a/pombot/commands/poms.py
+++ b/pombot/commands/poms.py
@@ -276,6 +276,7 @@ class _Session:
         """Generate the list of poms in the field as a plain string of at most
         `max_length` characters.
         """
+        join_fix = lambda s, n="\n": f"```fix\n{n.join(s)}```"
         pom_counts = Counter(pom.descript for pom in self.poms)
         descripts_and_counts: List[str] = []
 
@@ -283,13 +284,13 @@ class _Session:
             count = pom_counts[descript]
             descripts_and_counts += [f"{descript} ({count})"]
 
-            if len(candidate := ", ".join(descripts_and_counts)) < max_length:
+            if len(candidate := join_fix(descripts_and_counts)) < max_length:
                 continue
 
             # Last item put response candidate just over the limit.
             last_item = descripts_and_counts.pop()
 
-            yield ", ".join(descripts_and_counts)
+            yield join_fix(descripts_and_counts)
 
             descripts_and_counts = [last_item]
 

--- a/pombot/commands/poms.py
+++ b/pombot/commands/poms.py
@@ -126,25 +126,25 @@ async def do_poms(ctx: Context, *args):
             current_session.get_duration_message(),
         ])
 
-    try:
-        await send_embed_message(
-            None,
-            title=f"Your pom statistics",
-            description=current_session.get_session_started_message(),
-            thumbnail=ctx.author.avatar_url,
-            fields=[
-                banked_session.get_message_field(),
-                SPACER,
-                current_session.get_message_field(),
-            ],
-            footer=footer,
-            _func=(ctx.send if Debug.POMS_COMMAND_IS_PUBLIC else ctx.author.send),
-        )
-    except HTTPException:
-        await ctx.reply("this is a multi-message response etc etc")  # FIXME
-        await ctx.message.add_reaction(Reactions.ROBOT)
-    else:
-        await ctx.message.add_reaction(Reactions.CHECKMARK)
+    # try:
+    await send_embed_message(
+        None,
+        title=f"Your pom statistics",
+        description=current_session.get_session_started_message(),
+        thumbnail=ctx.author.avatar_url,
+        fields=[
+            banked_session.get_message_field(),
+            SPACER,
+            current_session.get_message_field(),
+        ],
+        footer=footer,
+        _func=(ctx.send if Debug.POMS_COMMAND_IS_PUBLIC else ctx.author.send),
+    )
+    # except HTTPException:
+    #     await ctx.reply("this is a multi-message response etc etc")  # FIXME
+    #     await ctx.message.add_reaction(Reactions.ROBOT)
+    # else:
+    await ctx.message.add_reaction(Reactions.CHECKMARK)
 
 
 class _Session:

--- a/pombot/commands/poms.py
+++ b/pombot/commands/poms.py
@@ -1,4 +1,3 @@
-from dataclasses import fields
 import textwrap
 from collections import Counter
 from datetime import timedelta

--- a/pombot/commands/poms.py
+++ b/pombot/commands/poms.py
@@ -276,10 +276,16 @@ class _Session:
         """Generate the list of poms in the field as a plain string of at most
         `max_length` characters.
         """
+        # FIXME add some text about "your poms went over some limit, rename a
+        # few. here they are"
         join_fix = lambda s, n="\n": f"```fix\n{n.join(s)}```"
         pom_counts = Counter(pom.descript for pom in self.poms)
         descripts_and_counts: List[str] = []
 
+        # FIXME should the be
+        # - alphabetized? (to make finding duplicates easier)
+        # - sorted by count (like in !poms)
+        # - unsorted (same order as when the first descript was added)
         for descript in sorted(pom_counts, key=str.casefold):
             count = pom_counts[descript]
             descripts_and_counts += [f"{descript} ({count})"]

--- a/pombot/commands/poms.py
+++ b/pombot/commands/poms.py
@@ -145,13 +145,14 @@ async def do_poms(ctx: Context, *args):
         for session in (current_session, banked_session):
             field = session.get_message_field()
 
-            if len(field.value) <= Limits.MAX_CHARACTERS_PER_MESSAGE:
+            if len(field.value) <= Limits.MAX_EMBED_FIELD_VALUE:
                 print("this one is good")  # FIXME
                 continue
 
             for message in session.iter_message_field(
                     max_length=Limits.MAX_CHARACTERS_PER_MESSAGE - 100):
-                await ctx.author.send(message)
+                await (ctx.author.send(message)
+                       if not Debug.POMS_COMMAND_IS_PUBLIC else ctx.send(message))
 
         await ctx.message.add_reaction(Reactions.ROBOT)
     else:
@@ -271,6 +272,8 @@ class _Session:
             if len(", ".join(descripts_and_counts)) <= max_length:
                 continue
 
+            # FIXME what's going on here? why isn't the debugger breaking on
+            # line 278 when the user has this many poms?
             # Last item put response candidate just over the limit.
             last_item = descripts_and_counts.pop()
 

--- a/pombot/commands/poms.py
+++ b/pombot/commands/poms.py
@@ -287,7 +287,6 @@ class _Session:
         """Generate the list of poms in the field as a plain string of at most
         `max_length` characters.
         """
-        # few. here they are"
         code_block_join = lambda s, n="\n": f"```{n.join(s)}```"
         pom_counts = Counter(pom.descript for pom in self.poms if pom.descript is not None)
         descripts_and_counts: List[str] = []

--- a/pombot/config.py
+++ b/pombot/config.py
@@ -70,15 +70,14 @@ class Debug:
     POMS_COMMAND_IS_PUBLIC = str2bool(os.getenv("POMS_COMMAND_IS_PUBLIC", "no"))
 
     @classmethod
-    def disable_all(cls) -> None:
-        """Override settings from environment variables and set all Debug
-        boolean options to False. Useful for unit tests.
+    def disable(cls) -> None:
+        """Override settings from environment variables and set all boolean
+        debug options to false. Useful for unit tests.
         """
-        all_attrs = ((p, getattr(cls, p)) for p in dir(cls))
-        only_bools = lambda p: isinstance(p[1], bool)
-
-        for attr, _ in filter(only_bools, all_attrs):
+        for attr, _ in filter(lambda p: isinstance(p[1], bool),
+                              ((p, getattr(cls, p)) for p in dir(cls))):
             setattr(cls, attr, False)
+
 
 class IconUrls:
     """Locations of Pombot's custom reactions and icons."""

--- a/pombot/config.py
+++ b/pombot/config.py
@@ -69,6 +69,17 @@ class Debug:
     BENCHMARK_POMWAR_ATTACK = str2bool(os.getenv("BENCHMARK_POMWAR_ATTACK", "no"))
     POMS_COMMAND_IS_PUBLIC = str2bool(os.getenv("POMS_COMMAND_IS_PUBLIC", "no"))
 
+    @classmethod
+    def disable_all(cls) -> None:
+        """Override settings from environment variables and set all Debug
+        boolean options to False. Useful for unit tests.
+        """
+        all_attrs = ((p, getattr(cls, p)) for p in dir(cls))
+        only_bools = lambda p: isinstance(p[1], bool)
+
+        for attr, _ in filter(only_bools, all_attrs):
+            setattr(cls, attr, False)
+
 class IconUrls:
     """Locations of Pombot's custom reactions and icons."""
     # The Pomato

--- a/pombot/data/__init__.py
+++ b/pombot/data/__init__.py
@@ -7,6 +7,20 @@ POM_WARS_DATA_DIR = THIS_DIR / "pom_wars"
 _log = logging.getLogger(__name__)
 
 
+class Limits:
+    """Character limits imposed by the Discord API."""
+    MAX_CHARACTERS_PER_MESSAGE = 2000
+    MAX_CHARACTERS_PER_EMBED = 6000
+
+    MAX_EMBED_TITLE       = 256
+    MAX_EMBED_DESCRIPTION = 2048
+    MAX_NUM_EMBED_FIELDS  = 25
+    MAX_EMBED_FIELD_NAME  = 256
+    MAX_EMBED_FIELD_VALUE = 1024
+    MAX_EMBED_FOOTER_TEXT = 2048
+    MAX_EMBED_AUTHOR_NAME = 256
+
+
 class Locations:
     """Path-like locations of data for the bot."""
     DISCLAIMERS = THIS_DIR / "disclaimers.xml"

--- a/pombot/lib/storage.py
+++ b/pombot/lib/storage.py
@@ -1,8 +1,9 @@
 import logging
+import sys
 from contextlib import asynccontextmanager
 from datetime import datetime as dt
 from datetime import time, timezone
-from typing import List, Optional, Set
+from typing import Iterable, List, Optional, Set, Union
 
 import aiomysql
 from discord.user import User as DiscordUser
@@ -165,11 +166,18 @@ class Storage:
     @staticmethod
     async def add_poms_to_user_session(
         user: DiscordUser,
-        descript: str,
+        descript: Optional[Union[str, Iterable]],
         count: int,
         time_set: dt = None,
     ):
-        """Add a number of user poms."""
+        """Add a number of user poms.
+
+        If `descript` is specified as a non-string iterable, like a list or
+        generator, then this will check that we're in a unit test and fail if
+        not. This is because it is generally only possible to have one pom
+        description per user command specified, but this makes unit tests that
+        require many poms in the DB very slow.
+        """
         query = f"""
             INSERT INTO {Config.POMS_TABLE} (
                 userID,
@@ -182,7 +190,16 @@ class Storage:
 
         descript = descript or None
         time_set = time_set or dt.now()
-        poms = [(user.id, descript, time_set, True) for _ in range(count)]
+
+        if type(descript) in [str, type(None)]:
+            poms = [(user.id, descript, time_set, True) for _ in range(count)]
+        else:
+            assert "unittest" in sys.modules, \
+                f"{type(descript)} not allowed for descript outside of unit tests"
+
+            poms = []
+            for desc in descript:
+                poms += [(user.id, desc, time_set, True) for _ in range(count)]
 
         async with _mysql_database_cursor() as cursor:
             await cursor.executemany(query, poms)

--- a/pombot/lib/storage.py
+++ b/pombot/lib/storage.py
@@ -197,9 +197,9 @@ class Storage:
             assert "unittest" in sys.modules, \
                 f"{type(descript)} not allowed for descript outside of unit tests"
 
-            poms = []
-            for desc in descript:
-                poms += [(user.id, desc, time_set, True) for _ in range(count)]
+            poms = [(user.id, desc, time_set, True)
+                    for desc in descript
+                    for _ in range(count)]
 
         async with _mysql_database_cursor() as cursor:
             await cursor.executemany(query, poms)

--- a/tests/helpers/mock_discord.py
+++ b/tests/helpers/mock_discord.py
@@ -144,7 +144,7 @@ class AsyncCheckRaiseResponse(unittest.mock.AsyncMock):
             total_embed_length += len(author_name)
 
         if total_embed_length > Limits.MAX_CHARACTERS_PER_EMBED:
-            self.raise_bad_request("total embed length is OVER 6,0000!")
+            self.raise_bad_request("total embed length is OVER 6,000!")
 
     @staticmethod
     async def raise_bad_request(data_category: str):

--- a/tests/helpers/mock_discord.py
+++ b/tests/helpers/mock_discord.py
@@ -15,6 +15,7 @@ Modifications to the original work:
     - Default `discriminator` attribute added to MockMember
     - Default `message` attribute added to MockContext.
     - AsyncMock `send` attribute added to MockContext.
+    - AsyncMock `reply` attribute added to MockMessage.
     - Various Pylint warnings ignored.
 """
 # pylint: disable=access-member-before-definition
@@ -485,6 +486,7 @@ class MockMessage(CustomMockMixin, unittest.mock.MagicMock):
         super().__init__(**collections.ChainMap(kwargs, default_kwargs))
         self.author = kwargs.get('author', MockMember())
         self.channel = kwargs.get('channel', MockTextChannel())
+        self.reply = unittest.mock.AsyncMock()
 
 
 emoji_data = {'require_colons': True, 'managed': True, 'id': 1, 'name': 'hyperlemon'}

--- a/tests/helpers/semantics.py
+++ b/tests/helpers/semantics.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def assert_not_raises():
+    """Context manager that does nothing.
+
+    When an exception occurs, it will be allowed raise.  This is semantic
+    sugar for the reader to know that the purpose of a line is to ensure that
+    the line does not raise an exception.
+    """
+    try:
+        yield
+    except Exception as e:  # FIXME
+        pass

--- a/tests/helpers/semantics.py
+++ b/tests/helpers/semantics.py
@@ -9,7 +9,4 @@ def assert_not_raises():
     sugar for the reader to know that the purpose of a line is to ensure that
     the line does not raise an exception.
     """
-    try:
-        yield
-    except Exception as e:  # FIXME
-        pass
+    yield

--- a/tests/test_commands_fortune.py
+++ b/tests/test_commands_fortune.py
@@ -29,7 +29,7 @@ class TestFortuneCommand(IsolatedAsyncioTestCase):
         await pombot.commands.do_fortune(self.ctx)
         embeds_sent_to_user += [self.ctx.send.call_args.kwargs.get("embed")]
 
-        self.assertEqual(2, self.ctx.send.await_count)
+        self.assertEqual(2, self.ctx.send.call_count)
 
         # We expect the message descriptions to change between calls, but the
         # footer's "lucky numbers" should remain constant.

--- a/tests/test_commands_poms.py
+++ b/tests/test_commands_poms.py
@@ -1,9 +1,15 @@
 import unittest
+from unittest.mock import patch
 from unittest.async_case import IsolatedAsyncioTestCase
 
+from discord.embeds import Embed
+from parameterized import parameterized
+
 import pombot
+from pombot.config import Config
 from pombot.lib.storage import Storage
 from tests.helpers.mock_discord import MockContext
+from tests.helpers.semantics import assert_not_raises
 
 
 class TestPomsCommand(IsolatedAsyncioTestCase):
@@ -20,45 +26,68 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
         """Cleanup the database."""
         await Storage.delete_all_rows_from_all_tables()
 
-    async def test_poms_command_with_no_args(self):
-        """Test the user typing `!poms` with an empty session and bank."""
-        self.ctx.invoked_with = "poms"
+    @parameterized.expand(["!poms", "!poms.show"])
+    async def test_poms_command_with_no_args(self, invoked_with: str):
+        """Test the user typing `!poms` and `!poms.show` with an empty
+        session and bank.
+        """
+        self.ctx.invoked_with = invoked_with.removeprefix("!")
         await pombot.commands.do_poms(self.ctx)
 
-        # The user was DM'd an embed.
-        self.assertTrue(self.ctx.author.send)
-        embed_sent_to_user = self.ctx.author.send.call_args.kwargs["embed"]
+        if response_is_public := self.ctx.invoked_with in Config.PUBLIC_POMS_ALIASES:
+            self.assertEqual(1, self.ctx.message.reply.await_count)
+            embed_sent_to_user = self.ctx.message.reply.call_args.kwargs["embed"]
+        else:
+            self.assertEqual(1, self.ctx.author.send.await_count)
+            embed_sent_to_user = self.ctx.author.send.call_args.kwargs["embed"]
 
-        # The embed tells the user that no session is active.
-        self.assertIn("Session not yet started.", embed_sent_to_user.description)
+        if response_is_public:
+            self.assertEqual(Embed.Empty, embed_sent_to_user.description)
 
-        # It contains three fields.
-        self.assertEqual(3, len(embed_sent_to_user.fields))
+            expected_fields_sent_to_user = [
+                {
+                    "name": "**Current Session**",
+                    "value": "Start your session by doing\nyour first !pom.\n",
+                    "inline": True,
+                },
+            ]
+        else:
+            self.assertIn("Session not yet started.", embed_sent_to_user.description)
 
-        # And the fields contents are as follows.
-        expected_fields_sent_to_user = [
-            {
-                "name": "**Banked Poms**",
-                "value": "Bank the poms in your current\nsession to add them here!\n",
-                "inline": True,
-            },
-            {
-                "name": "\u200b",  # Zero-width space.
-                "value": "\u200b",  # Zero-width space.
-                "inline": True,
-            },
-            {
-                "name": "**Current Session**",
-                "value": "Start your session by doing\nyour first !pom.\n",
-                "inline": True,
-            },
-        ]
+            expected_fields_sent_to_user = [
+                {
+                    "name": "**Banked Poms**",
+                    "value": "Bank the poms in your current\nsession to add them here!\n",
+                    "inline": True,
+                },
+                {
+                    "name": "\u200b",  # Zero-width space.
+                    "value": "\u200b",  # Zero-width space.
+                    "inline": True,
+                },
+                {
+                    "name": "**Current Session**",
+                    "value": "Start your session by doing\nyour first !pom.\n",
+                    "inline": True,
+                },
+            ]
+
+        self.assertEqual(len(expected_fields_sent_to_user),
+                         len(embed_sent_to_user.fields))
 
         for expected, actual in zip(expected_fields_sent_to_user,
                                     embed_sent_to_user.fields):
             self.assertEqual(expected["name"], actual.name)
             self.assertEqual(expected["value"], actual.value)
             self.assertEqual(expected["inline"], actual.inline)
+
+    # @unittest.mock.patch
+    # async def test_embed_too_long_causes_normal_message(self):
+    #     """Test the user typing `!poms` when the response of the message
+    #     would be at least 1,024 characters.
+    #     """
+    #     self.ctx.invoked_with = "poms"
+    #     await pombot.commands.do_poms(self.ctx)
 
 
 if __name__ == "__main__":

--- a/tests/test_commands_poms.py
+++ b/tests/test_commands_poms.py
@@ -7,7 +7,7 @@ from discord.embeds import Embed
 from parameterized import parameterized
 
 import pombot
-from pombot.config import Config
+from pombot.config import Config, Debug
 from pombot.lib.storage import Storage
 from tests.helpers.mock_discord import MockContext
 from tests.helpers.semantics import assert_not_raises
@@ -19,6 +19,7 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         """Ensure database tables exist and create contexts for the tests."""
+        Debug.disable_all()
         self.ctx = MockContext()
         await Storage.create_tables_if_not_exists()
         await Storage.delete_all_rows_from_all_tables()
@@ -94,6 +95,9 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
             random.choice(string.ascii_letters + string.digits)
             for _ in range(30)) for _ in range(201))
         await Storage.add_poms_to_user_session(self.ctx.author, descriptions, 1)
+
+        # Have at least one "Undesignated" pom.
+        await Storage.add_poms_to_user_session(self.ctx.author, None, 1)
 
         with assert_not_raises():
             self.ctx.invoked_with = "poms"

--- a/tests/test_commands_poms.py
+++ b/tests/test_commands_poms.py
@@ -1,5 +1,6 @@
+import random
+import string
 import unittest
-from unittest.mock import patch
 from unittest.async_case import IsolatedAsyncioTestCase
 
 from discord.embeds import Embed
@@ -81,13 +82,21 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
             self.assertEqual(expected["value"], actual.value)
             self.assertEqual(expected["inline"], actual.inline)
 
-    # @unittest.mock.patch
-    # async def test_embed_too_long_causes_normal_message(self):
-    #     """Test the user typing `!poms` when the response of the message
-    #     would be at least 1,024 characters.
-    #     """
-    #     self.ctx.invoked_with = "poms"
-    #     await pombot.commands.do_poms(self.ctx)
+    async def test_embed_too_long_causes_normal_message(self):
+        """Test the user typing `!poms` when the response of the message
+        would exceed Discord limits.
+        """
+        # Deterministically generate pom descriptions.
+        random.seed(42)
+
+        # Make our combined pom descriptions over 6,000 characters.
+        descriptions = ("".join(
+            random.choice(string.ascii_letters + string.digits)
+            for _ in range(30)) for _ in range(201))
+        await Storage.add_poms_to_user_session(self.ctx.author, descriptions, 1)
+
+        self.ctx.invoked_with = "poms"
+        await pombot.commands.do_poms(self.ctx)
 
 
 if __name__ == "__main__":

--- a/tests/test_commands_poms.py
+++ b/tests/test_commands_poms.py
@@ -36,10 +36,10 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
         await pombot.commands.do_poms(self.ctx)
 
         if response_is_public := self.ctx.invoked_with in Config.PUBLIC_POMS_ALIASES:
-            self.assertEqual(1, self.ctx.message.reply.await_count)
+            self.assertEqual(1, self.ctx.message.reply.call_count)
             embed_sent_to_user = self.ctx.message.reply.call_args.kwargs["embed"]
         else:
-            self.assertEqual(1, self.ctx.author.send.await_count)
+            self.assertEqual(1, self.ctx.author.send.call_count)
             embed_sent_to_user = self.ctx.author.send.call_args.kwargs["embed"]
 
         if response_is_public:
@@ -95,8 +95,9 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
             for _ in range(30)) for _ in range(201))
         await Storage.add_poms_to_user_session(self.ctx.author, descriptions, 1)
 
-        self.ctx.invoked_with = "poms"
-        await pombot.commands.do_poms(self.ctx)
+        with assert_not_raises():
+            self.ctx.invoked_with = "poms"
+            await pombot.commands.do_poms(self.ctx)
 
 
 if __name__ == "__main__":

--- a/tests/test_commands_poms.py
+++ b/tests/test_commands_poms.py
@@ -99,6 +99,12 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
             self.ctx.invoked_with = "poms"
             await pombot.commands.do_poms(self.ctx)
 
+        # test that messages were DM'd to user
+
+        # test that DM'd messages included saying that the Bank was fine.
+
+        # test that all poms descripts are somewhere in the messages
+
         pass
 
 

--- a/tests/test_commands_poms.py
+++ b/tests/test_commands_poms.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.async_case import IsolatedAsyncioTestCase
+
+import pombot
+from pombot.lib.storage import Storage
+from tests.helpers.mock_discord import MockContext
+
+
+class TestPomsCommand(IsolatedAsyncioTestCase):
+    """Test the !poms command."""
+    ctx = None
+
+    async def asyncSetUp(self) -> None:
+        """Ensure database tables exist and create contexts for the tests."""
+        self.ctx = MockContext()
+        await Storage.create_tables_if_not_exists()
+        await Storage.delete_all_rows_from_all_tables()
+
+    async def asyncTearDown(self) -> None:
+        """Cleanup the database."""
+        await Storage.delete_all_rows_from_all_tables()
+
+    async def test_poms_command_with_no_args(self):
+        """Test the user typing `!poms` with an empty session and bank."""
+        self.ctx.invoked_with = "poms"
+        await pombot.commands.do_poms(self.ctx)
+
+        # The user was DM'd an embed.
+        self.assertTrue(self.ctx.author.send)
+        embed_sent_to_user = self.ctx.author.send.call_args.kwargs["embed"]
+
+        # The embed tells the user that no session is active.
+        self.assertIn("Session not yet started.", embed_sent_to_user.description)
+
+        # It contains three fields.
+        self.assertEqual(3, len(embed_sent_to_user.fields))
+
+        # And the fields contents are as follows.
+        expected_fields_sent_to_user = [
+            {
+                "name": "**Banked Poms**",
+                "value": "Bank the poms in your current\nsession to add them here!\n",
+                "inline": True,
+            },
+            {
+                "name": "\u200b",  # Zero-width space.
+                "value": "\u200b",  # Zero-width space.
+                "inline": True,
+            },
+            {
+                "name": "**Current Session**",
+                "value": "Start your session by doing\nyour first !pom.\n",
+                "inline": True,
+            },
+        ]
+
+        for expected, actual in zip(expected_fields_sent_to_user,
+                                    embed_sent_to_user.fields):
+            self.assertEqual(expected["name"], actual.name)
+            self.assertEqual(expected["value"], actual.value)
+            self.assertEqual(expected["inline"], actual.inline)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_commands_poms.py
+++ b/tests/test_commands_poms.py
@@ -99,6 +99,8 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
             self.ctx.invoked_with = "poms"
             await pombot.commands.do_poms(self.ctx)
 
+        pass
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_commands_poms.py
+++ b/tests/test_commands_poms.py
@@ -19,7 +19,7 @@ class TestPomsCommand(IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         """Ensure database tables exist and create contexts for the tests."""
-        Debug.disable_all()
+        Debug.disable()
         self.ctx = MockContext()
         await Storage.create_tables_if_not_exists()
         await Storage.delete_all_rows_from_all_tables()


### PR DESCRIPTION
Painstakingly resolves PPB-54 by handling the HTTPException and sending the user a bunch of DM's instead. It's not possible for this list to show up in the channel unless `Debug.POMS_COMMAND_IS_PUBLIC` is set, but this should never be the case in prod.

Beware: Here be dragons.

@debashisbiswas @zmontgo 